### PR TITLE
Add lxml as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ textstat>=0.6.2
 pyspellchecker>=0.7.0
 ruamel.yaml>=0.17.21
 Pygments>=2.13.0
+lxml>=4.9.2


### PR DESCRIPTION
Whenever I try to follow the steps on xrpl-dev-portal to install Dactyl, the initial `dactyl_build` fails with the error `Couldn't find a tree builder with the features you requested: xml. Do you need to install a parser library?.` until I install `lxml` - I think that means that `lxml` should be in the requirements for the tool, although maybe I'm wrong.